### PR TITLE
Add static version of ZSTD, enable multi-threading mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,34 @@
-cmake_minimum_required(VERSION 3.20)
-project(spz VERSION 1.0.0 LANGUAGES CXX)
+cmake_minimum_required(VERSION 3.29)
 
-option(USE_MARCH_NATIVE "Enable -march=native for release builds" OFF)
+project(spz
+    VERSION 1.0.0
+    LANGUAGES CXX
+    DESCRIPTION "SPZ Library and Tools"
+)
+
+# Build options
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(BUILD_PYTHON_BINDINGS "Build Python bindings" ON)
+option(USE_MARCH_NATIVE "Enable -march=native for release builds" OFF)
+option(USE_STATIC_ZSTD "Build and link against static zstd library" ON)
 
+# Debug options
 option(ENABLE_ASAN "Enable Address Sanitizer" OFF)
 option(ENABLE_UBSAN "Enable Undefined Behavior Sanitizer" OFF)
 
+# Core settings
 set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-# Configure third-party libraries
-find_package(zstd REQUIRED)
-include_directories(${ZSTD_INCLUDE_DIRS})
+# Include external content manager
+include(FetchContent)
+include(CheckIPOSupported)
 
+# Python bindings setup
 if(BUILD_PYTHON_BINDINGS)
     find_package(Python COMPONENTS Interpreter Development REQUIRED)
 
-    # Find or fetch pybind11
-    include(FetchContent)
     FetchContent_Declare(
         pybind11
         GIT_REPOSITORY https://github.com/pybind/pybind11.git
@@ -28,9 +37,36 @@ if(BUILD_PYTHON_BINDINGS)
     FetchContent_MakeAvailable(pybind11)
 endif()
 
-include(CheckIPOSupported)
-check_ipo_supported(RESULT ipo_supported OUTPUT error)
+# ZSTD setup
+FetchContent_Declare(
+    zstd
+    GIT_REPOSITORY https://github.com/facebook/zstd.git
+    GIT_TAG v1.5.6
+)
+FetchContent_MakeAvailable(zstd)
 
+# Configure ZSTD build options
+set(ZSTD_MULTITHREAD ON CACHE BOOL "Enable multithreading in Zstd" FORCE)
+if (${USE_STATIC_ZSTD})
+  set(ZSTD_BUILD_STATIC ${USE_STATIC_ZSTD} CACHE BOOL "Build static Zstd library" FORCE)
+elseif()
+  set(ZSTD_BUILD_SHARED ON CACHE BOOL "Build shared Zstd library" FORCE)
+endif()
+
+# Add ZSTD CMake configuration
+add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/_deps/zstd-src/build/cmake zstd)
+
+# Set up ZSTD target alias based on linking preference
+if(USE_STATIC_ZSTD)
+    add_library(zstd::zstd ALIAS libzstd_static)
+else()
+    add_library(zstd::zstd ALIAS libzstd_shared)
+endif()
+
+# Check for LTO support
+check_ipo_supported(RESULT IPO_SUPPORTED OUTPUT IPO_ERROR)
+
+# Define source files
 set(LIBRARY_SOURCES
     src/cc/load-spz.cc
     src/cc/splat-c-types.cc
@@ -41,47 +77,48 @@ set(EXECUTABLE_SOURCES
     src/cc/main.cc
 )
 
-# Define shared library target
+# Shared library target
 add_library(spz_shared SHARED ${LIBRARY_SOURCES})
 target_compile_definitions(spz_shared PRIVATE SPZ_BUILDING_SHARED)
 set_target_properties(spz_shared PROPERTIES
-    VERSION 1.0.0
-    SOVERSION 1
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}
     OUTPUT_NAME "spz"
 )
-target_include_directories(spz_shared
-    PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-        $<INSTALL_INTERFACE:include>
-    PRIVATE
-        src/cc
-)
-target_link_libraries(spz_shared PRIVATE zstd)
 
-# Define static library target with PIC
+# Static library target
 add_library(spz_static STATIC ${LIBRARY_SOURCES})
-target_compile_definitions(spz_static PRIVATE SPZ_BUILDING_STATIC)
+target_compile_definitions(spz_static
+    PRIVATE
+        SPZ_BUILDING_STATIC
+)
 set_target_properties(spz_static PROPERTIES
     OUTPUT_NAME "spz"
-    VERSION 1.0.0
+    VERSION ${PROJECT_VERSION}
     POSITION_INDEPENDENT_CODE ON
 )
-target_include_directories(spz_static
-    PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-        $<INSTALL_INTERFACE:include>
-    PRIVATE
-        src/cc
-)
-target_link_libraries(spz_static PRIVATE zstd)
 
+# Common include directories for both libraries
+foreach(target spz_shared spz_static)
+    target_include_directories(${target}
+        PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+            $<INSTALL_INTERFACE:include>
+        PRIVATE
+            src/cc
+    )
+    target_link_libraries(${target} PRIVATE zstd::zstd)
+endforeach()
+
+# Executable target
 add_executable(spz_exe ${EXECUTABLE_SOURCES})
 set_target_properties(spz_exe PROPERTIES OUTPUT_NAME "spz")
 target_include_directories(spz_exe PRIVATE src src/cc)
-target_link_libraries(spz_exe PRIVATE spz_static zstd)
+target_link_libraries(spz_exe PRIVATE spz_static zstd::zstd)
 
+# Sanitizer configuration
 if(ENABLE_ASAN OR ENABLE_UBSAN)
-    set(SANITIZER_FLAGS)
+    set(SANITIZER_FLAGS "")
 
     if(ENABLE_ASAN)
         message(STATUS "Address Sanitizer (ASAN) enabled for executable")
@@ -93,18 +130,15 @@ if(ENABLE_ASAN OR ENABLE_UBSAN)
         list(APPEND SANITIZER_FLAGS "-fsanitize=undefined")
     endif()
 
-    # Apply sanitizer flags to the executable target
-    if(SANITIZER_FLAGS)
-        target_compile_options(spz_exe PRIVATE ${SANITIZER_FLAGS})
-        target_link_options(spz_exe PRIVATE ${SANITIZER_FLAGS})
-    endif()
+    target_compile_options(spz_exe PRIVATE ${SANITIZER_FLAGS})
+    target_link_options(spz_exe PRIVATE ${SANITIZER_FLAGS})
 endif()
 
+# Python bindings configuration
 if(BUILD_PYTHON_BINDINGS)
     pybind11_add_module(pyspz src/cc/python/bindings.cc)
     target_include_directories(pyspz PRIVATE src src/cc)
-
-    target_link_libraries(pyspz PRIVATE spz_static zstd)
+    target_link_libraries(pyspz PRIVATE spz_static zstd::zstd)
 
     set_target_properties(pyspz PROPERTIES
         LIBRARY_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/pyspz"
@@ -113,17 +147,19 @@ if(BUILD_PYTHON_BINDINGS)
     )
 endif()
 
-# Configure build settings for Release, ReleaseWithDebugInfo is used for profiling
-if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "ReleaseWithDebugInfo")
-    if (ipo_supported)
-        message(STATUS "IPO / LTO enabled")
-        set_property(TARGET spz_shared PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
-        set_property(TARGET spz_static PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
-        set_property(TARGET spz_exe PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+# Release build optimizations
+if(CMAKE_BUILD_TYPE MATCHES "Release|RelWithDebInfo")
+    # Enable LTO if supported
+    if(IPO_SUPPORTED)
+        message(STATUS "Enabling Link Time Optimization (LTO)")
+        foreach(target spz_shared spz_static spz_exe)
+            set_property(TARGET ${target} PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+        endforeach()
     else()
-        message(STATUS "IPO / LTO not supported: <${error}>")
+        message(STATUS "LTO not supported: ${IPO_ERROR}")
     endif()
 
+    # Configure architecture-specific optimizations
     if(USE_MARCH_NATIVE)
         message(STATUS "Setting -march=native")
         set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -march=native")
@@ -136,32 +172,38 @@ if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "ReleaseWith
         elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm" OR CMAKE_SYSTEM_PROCESSOR MATCHES "aarch")
             # For ARM processors
             if(NOT CMAKE_CXX_FLAGS_RELEASE MATCHES "march=")
-                set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -march=armv8-a")
+                set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -march=armv8.2-a")
             endif()
         else()
             message(WARNING "Unsupported architecture: -march option not set.")
         endif()
     endif()
 
-    # Write compile flags
-    file(WRITE "${CMAKE_BINARY_DIR}/compile_flags.txt" "CXXFLAGS: ${CMAKE_CXX_FLAGS_RELEASE}\n")
-    file(APPEND "${CMAKE_BINARY_DIR}/compile_flags.txt" "LINKER_FLAGS: ${CMAKE_EXE_LINKER_FLAGS}\n")
+    # Generate build information
+    file(WRITE ${CMAKE_BINARY_DIR}/build_info.txt
+        "Build Configuration:\n"
+        "CMake Version: ${CMAKE_VERSION}\n"
+        "Build Type: ${CMAKE_BUILD_TYPE}\n"
+        "\n"
+        "Compiler Information:\n"
+        "Compiler: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}\n"
+        "Compiler Path: ${CMAKE_CXX_COMPILER}\n"
+        "CMAKE_CXX_FLAGS_RELEASE: ${CMAKE_CXX_FLAGS_RELEASE}\n"
+        "\n"
+        "Linker Information:\n"
+        "Linker: ${CMAKE_LINKER}\n"
+        "Linker Flags: ${CMAKE_EXE_LINKER_FLAGS}\n"
+        "Static ZSTD: ${USE_STATIC_ZSTD}\n"
+        "LTO Enabled: ${IPO_SUPPORTED}\n"
+        "\n"
+    )
 endif()
 
-target_include_directories(spz_shared
-    PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-        $<INSTALL_INTERFACE:include>
-    PRIVATE
-        src/cc
-)
-
-target_include_directories(spz_static
-    PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-        $<INSTALL_INTERFACE:include>
-    PRIVATE
-        src/cc
+# Installation configuration
+install(TARGETS spz_shared spz_static
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
 )
 
 if(BUILD_PYTHON_BINDINGS)

--- a/README.md
+++ b/README.md
@@ -8,10 +8,34 @@ This is a modified version of the [SPZ library](https://github.com/nianticlabs/s
 - **Improved Performance**: The default `march` target is set to `x86-64-v3`, along with various small fixes and optimizations for better performance.
 - **Python Bindings**: Python bindings have been implemented using `pybind11`.
 
-## Interface
+## C++ Interface
 ```C
 std::vector<uint8_t> compress(const std::vector<uint8_t> &rawData, int compressionLevel);
 std::vector<uint8_t> decompress(const std::vector<uint8_t> &input, bool includeNormals);
+```
+
+## Python Interface
+```Python
+def compress(raw_data: bytes, compression_level: int = 1, workers: int = 1) -> bytes:
+    """
+    Compresses the provided raw data.
+
+    :param raw_data: Data to compress as a bytes object.
+    :param compression_level: Level of compression (default is 1).
+    :param workers: Number of worker threads to use (default is 1).
+    :return: Compressed data as a bytes object.
+    :raises RuntimeError: If compression fails.
+    """
+
+def decompress(input_data: bytes, include_normals: bool) -> bytes:
+    """
+    Decompresses the provided input data.
+
+    :param input_data: Compressed data as a bytes object.
+    :param include_normals: Whether to include normals in the decompressed data.
+    :return: Decompressed data as a bytes object.
+    :raises RuntimeError: If decompression fails.
+    """
 ```
 
 ## File Format
@@ -99,7 +123,7 @@ import pyspz
 import os
 import time
 
-def compress_ply(input_ply_path, compressed_path, compression_level=1):
+def compress_ply(input_ply_path, compressed_path, compression_level=1, int workers=1):
     """
     Compresses a PLY file and saves the compressed data.
     """
@@ -107,7 +131,7 @@ def compress_ply(input_ply_path, compressed_path, compression_level=1):
         raw_data = f.read()
 
     start_time = time.perf_counter()
-    compressed_data = pyspz.compress(raw_data, compression_level)
+    compressed_data = pyspz.compress(raw_data, compression_level, workers)
     end_time = time.perf_counter()
 
     with open(compressed_path, 'wb') as f:
@@ -146,7 +170,8 @@ def main():
         return
 
     compression_level = 3
-    compress_ply(input_ply, compressed_file, compression_level)
+    workers = 3
+    compress_ply(input_ply, compressed_file, compression_level, workers)
     decompress_ply(compressed_file, decompressed_ply, include_normals=False)
 
 if __name__ == "__main__":

--- a/src/cc/load-spz.h
+++ b/src/cc/load-spz.h
@@ -56,7 +56,7 @@ struct PackedGaussians {
 };
 
 // Saves Gaussian splat in packed format, returning a vector of bytes.
-bool saveSpz(const GaussianCloud &g, std::vector<uint8_t> *output, int compressionLevel);
+bool saveSpz(const GaussianCloud &g, std::vector<uint8_t> *output, int compressionLevel, int workers);
 
 // Loads Gaussian splat from a vector of bytes in packed format.
 GaussianCloud loadSpz(const std::vector<uint8_t> &data);
@@ -67,7 +67,7 @@ PackedGaussians loadSpzPacked(const uint8_t* data, int size);
 PackedGaussians loadSpzPacked(const std::vector<uint8_t> &data);
 
 // Saves Gaussian splat in packed format to a file
-bool saveSpz(const GaussianCloud &g, const std::string &filename, int compressionLevel);
+bool saveSpz(const GaussianCloud &g, const std::string &filename, int compressionLevel, int workers);
 
 // Loads Gaussian splat from a file in packed format
 GaussianCloud loadSpz(const std::string &filename);
@@ -83,6 +83,7 @@ GaussianCloud loadSplatFromMemory(const std::vector<char> &buffer);
 
 bool compress(const std::span<const uint8_t> rawData,
              int compressionLevel,
+             int workers,
              std::vector<uint8_t> &output);
 bool decompress(const std::span<const uint8_t> input,
                bool includeNormals,

--- a/src/cc/main.cc
+++ b/src/cc/main.cc
@@ -12,202 +12,233 @@
 namespace fs = std::filesystem;
 
 struct ProgramOptions {
-    bool compress = false;
-    bool decompress = false;
-    std::string inputFilename;
-    std::string outputFilename;
-    int compressionLevel = 3;
-    bool includeNormals = true;
-    std::string programName;
+  bool compress = false;
+  bool decompress = false;
+  std::string inputFilename;
+  std::string outputFilename;
+  int compressionLevel = 3;
+  bool includeNormals = false;
+  std::string programName;
+  int workers = 3;
 };
 
 void printUsage(const std::string &programName) {
-    std::cout
-        << "Usage:\n"
-        << "  " << programName
-        << " -e|-d -i <input_file> -o <output_file> [-c <compression_level>] [-n]\n\n"
-        << "Options:\n"
-        << "  -e                     Compress the input file to SPZ format.\n"
-        << "  -d                     Decompress the input SPZ file to PLY format.\n"
-        << "  -i <input_file>        Specify the input file.\n"
-        << "  -o <output_file>       Specify the output file.\n"
-        << "  -c <compression_level> (Optional) Specify the compression level (1-22). Default is 5.\n"
-        << "  -n, --no-normals       (Optional, Decompress only) Exclude normals from the output PLY file.\n"
-        << "  -h, --help             Show this help message.\n";
+  std::cout
+      << "Usage:\n"
+      << "  " << programName
+      << " -e|-d -i <input_file> -o <output_file> [-c <compression_level>] [-w "
+         "<workers>] [-n]\n\n"
+      << "Options:\n"
+      << "  -e                     Compress the input file to SPZ format.\n"
+      << "  -d                     Decompress the input SPZ file to PLY "
+         "format.\n"
+      << "  -i <input_file>        Specify the input file.\n"
+      << "  -o <output_file>       Specify the output file.\n"
+      << "  -c <compression_level> (Optional) Specify the compression level "
+         "(1-22). Default is 3.\n"
+      << "  -w <workers>           (Optional) Specify the number of worker "
+         "threads. Default is the number of hardware threads.\n"
+      << "  -n, -normals           (Optional, Decompress only) Include normals "
+         "from the output PLY file.\n"
+      << "  -h, --help             Show this help message.\n";
 }
 
 bool handleError(const std::string &message, const std::string &programName) {
-    std::cerr << "Error: " << message << "\n";
-    printUsage(programName);
-    return false;
+  std::cerr << "Error: " << message << "\n";
+  printUsage(programName);
+  return false;
 }
 
 bool parseArguments(int argc, char *argv[], ProgramOptions &options) {
-    if (argc == 0) {
-        return handleError("No arguments provided.", "program");
-    }
+  if (argc == 0) {
+    return handleError("No arguments provided.", "program");
+  }
 
-    options.programName = argv[0];
+  options.programName = argv[0];
 
-    for (int i = 1; i < argc; ++i) {
-        std::string arg = argv[i];
-        if (arg == "-e") {
-            options.compress = true;
-        } else if (arg == "-d") {
-            options.decompress = true;
-        } else if (arg == "-i" && i + 1 < argc) {
-            options.inputFilename = argv[++i];
-        } else if (arg == "-o" && i + 1 < argc) {
-            options.outputFilename = argv[++i];
-        } else if (arg == "-c" && i + 1 < argc) {
-            options.compressionLevel = std::atoi(argv[++i]);
-            if (options.compressionLevel < 1 || options.compressionLevel > 22) {
-                return handleError("Compression level must be between 1 and 22.", options.programName);
-            }
-        } else if (arg == "-n" || arg == "--no-normals") {
-            options.includeNormals = false;
-        } else if (arg == "-h" || arg == "--help") {
-            printUsage(options.programName);
-            exit(0);
-        } else {
-            return handleError("Unknown or incomplete option: " + arg, options.programName);
-        }
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    if (arg == "-e") {
+      options.compress = true;
+    } else if (arg == "-d") {
+      options.decompress = true;
+    } else if (arg == "-i" && i + 1 < argc) {
+      options.inputFilename = argv[++i];
+    } else if (arg == "-o" && i + 1 < argc) {
+      options.outputFilename = argv[++i];
+    } else if (arg == "-c" && i + 1 < argc) {
+      options.compressionLevel = std::atoi(argv[++i]);
+      if (options.compressionLevel < 1 || options.compressionLevel > 22) {
+        return handleError("Compression level must be between 1 and 22.",
+                           options.programName);
+      }
+    } else if (arg == "-w" && i + 1 < argc) {
+      options.workers = std::atoi(argv[++i]);
+      if (options.workers < 1) {
+        return handleError("Number of workers must be at least 1.",
+                           options.programName);
+      }
+    } else if (arg == "-n" || arg == "-normals") {
+      options.includeNormals = true;
+    } else if (arg == "-h" || arg == "--help") {
+      printUsage(options.programName);
+      exit(0);
+    } else {
+      return handleError("Unknown or incomplete option: " + arg,
+                         options.programName);
     }
+  }
 
-    if (options.compress && options.decompress) {
-        return handleError("Specify either -e (compress) or -d (decompress), but not both.", options.programName);
-    }
-    if (!options.compress && !options.decompress) {
-        return handleError("Specify either -e (compress) or -d (decompress).", options.programName);
-    }
-    if (options.inputFilename.empty()) {
-        return handleError("Input file not specified. Use -i <input_file>.", options.programName);
-    }
-    if (options.outputFilename.empty()) {
-        return handleError("Output file not specified. Use -o <output_file>.", options.programName);
-    }
+  if (options.compress && options.decompress) {
+    return handleError(
+        "Specify either -e (compress) or -d (decompress), but not both.",
+        options.programName);
+  }
+  if (!options.compress && !options.decompress) {
+    return handleError("Specify either -e (compress) or -d (decompress).",
+                       options.programName);
+  }
+  if (options.inputFilename.empty()) {
+    return handleError("Input file not specified. Use -i <input_file>.",
+                       options.programName);
+  }
+  if (options.outputFilename.empty()) {
+    return handleError("Output file not specified. Use -o <output_file>.",
+                       options.programName);
+  }
 
-    return true;
+  return true;
 }
 
 int compressFile(const ProgramOptions &options) {
-    std::cout << "Compressing " << options.inputFilename << " to " << options.outputFilename
-              << " with compression level " << options.compressionLevel << "...\n";
+  std::cout << "Compressing " << options.inputFilename << " to "
+            << options.outputFilename << " with compression level "
+            << options.compressionLevel << " using " << options.workers
+            << " worker(s)...\n";
 
-    if (!fs::exists(options.inputFilename)) {
-        std::cerr << "Input file does not exist: " << options.inputFilename << "\n";
-        return 1;
-    }
+  if (!fs::exists(options.inputFilename)) {
+    std::cerr << "Input file does not exist: " << options.inputFilename << "\n";
+    return 1;
+  }
 
-    uintmax_t inputSize = fs::file_size(options.inputFilename);
-    std::cout << "Input file size: " << inputSize << " bytes.\n";
+  uintmax_t inputSize = fs::file_size(options.inputFilename);
+  std::cout << "Input file size: " << inputSize << " bytes.\n";
 
-    // Load Gaussian cloud from PLY file
-    spz::GaussianCloud cloud = spz::loadSplatFromPly(options.inputFilename);
-    if (cloud.numPoints == 0) {
-        std::cerr << "Failed to load Gaussian cloud from " << options.inputFilename << "\n";
-        return 1;
-    }
-    std::cout << "Loaded Gaussian cloud from " << options.inputFilename << " with "
-              << cloud.numPoints << " points.\n";
+  // Load Gaussian cloud from PLY file
+  spz::GaussianCloud cloud = spz::loadSplatFromPly(options.inputFilename);
+  if (cloud.numPoints == 0) {
+    std::cerr << "Failed to load Gaussian cloud from " << options.inputFilename
+              << "\n";
+    return 1;
+  }
+  std::cout << "Loaded Gaussian cloud from " << options.inputFilename
+            << " with " << cloud.numPoints << " points.\n";
 
-    auto start = std::chrono::high_resolution_clock::now();
-    std::vector<uint8_t> data;
+  auto start = std::chrono::high_resolution_clock::now();
+  std::vector<uint8_t> data;
 
-    if (!spz::saveSpz(cloud, &data, options.compressionLevel)) {
-        std::cerr << "Failed to encode Gaussian cloud to SPZ format\n";
-        return 1;
-    }
+  if (!spz::saveSpz(cloud, &data, options.compressionLevel, options.workers)) {
+    std::cerr << "Failed to encode Gaussian cloud to SPZ format\n";
+    return 1;
+  }
 
-    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
-                        std::chrono::high_resolution_clock::now() - start)
-                        .count();
-    std::cout << "Compression completed in " << duration << " ms.\n";
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+                      std::chrono::high_resolution_clock::now() - start)
+                      .count();
+  std::cout << "Compression completed in " << duration << " ms.\n";
 
-    // Write compressed data to output file
-    std::ofstream outFile(options.outputFilename, std::ios::binary);
-    if (!outFile) {
-        std::cerr << "Failed to open output file: " << options.outputFilename << "\n";
-        return 1;
-    }
-    outFile.write(reinterpret_cast<const char *>(data.data()), data.size());
-    if (!outFile) {
-        std::cerr << "Failed to write data to output file: " << options.outputFilename << "\n";
-        return 1;
-    }
+  // Write compressed data to output file
+  std::ofstream outFile(options.outputFilename, std::ios::binary);
+  if (!outFile) {
+    std::cerr << "Failed to open output file: " << options.outputFilename
+              << "\n";
+    return 1;
+  }
+  outFile.write(reinterpret_cast<const char *>(data.data()), data.size());
+  if (!outFile) {
+    std::cerr << "Failed to write data to output file: "
+              << options.outputFilename << "\n";
+    return 1;
+  }
 
-    std::cout << "Compressed data saved to " << options.outputFilename << "\n";
+  std::cout << "Compressed data saved to " << options.outputFilename << "\n";
 
-    // Calculate and display size reduction
-    double sizeReduction = inputSize > 0
-                               ? (static_cast<double>(inputSize - data.size()) / inputSize) * 100.0
-                               : 0.0;
-    double compressionFactor = inputSize > 0
-                                   ? static_cast<double>(inputSize) / data.size()
-                                   : 0.0;
+  // Calculate and display size reduction
+  double sizeReduction =
+      inputSize > 0
+          ? (static_cast<double>(inputSize - data.size()) / inputSize) * 100.0
+          : 0.0;
+  double compressionFactor =
+      inputSize > 0 ? static_cast<double>(inputSize) / data.size() : 0.0;
 
-    std::cout << std::fixed << std::setprecision(2)
-              << "Size reduction: " << sizeReduction << "%\n"
-              << "Compressed file is " << compressionFactor
-              << " times smaller than the original.\n";
+  std::cout << std::fixed << std::setprecision(2)
+            << "Size reduction: " << sizeReduction << "%\n"
+            << "Compressed file is " << compressionFactor
+            << " times smaller than the original.\n";
 
-    return 0;
+  return 0;
 }
 
 int decompressFile(const ProgramOptions &options) {
-    std::cout << "Decompressing " << options.inputFilename << " to " << options.outputFilename;
-    if (!options.includeNormals) {
-        std::cout << " without normals";
-    }
-    std::cout << "...\n";
+  std::cout << "Decompressing " << options.inputFilename << " to "
+            << options.outputFilename;
+  if (options.includeNormals) {
+    std::cout << " with normals\n";
+  } else {
+    std::cout << " without normals\n";
+  }
 
-    if (!fs::exists(options.inputFilename)) {
-        std::cerr << "Input file does not exist: " << options.inputFilename << "\n";
-        return 1;
-    }
+  if (!fs::exists(options.inputFilename)) {
+    std::cerr << "Input file does not exist: " << options.inputFilename << "\n";
+    return 1;
+  }
 
-    std::ifstream inFile(options.inputFilename, std::ios::binary);
-    if (!inFile) {
-        std::cerr << "Failed to open input file: " << options.inputFilename << "\n";
-        return 1;
-    }
+  std::ifstream inFile(options.inputFilename, std::ios::binary);
+  if (!inFile) {
+    std::cerr << "Failed to open input file: " << options.inputFilename << "\n";
+    return 1;
+  }
 
-    std::vector<uint8_t> data((std::istreambuf_iterator<char>(inFile)), std::istreambuf_iterator<char>());
-    inFile.close();
+  std::vector<uint8_t> data((std::istreambuf_iterator<char>(inFile)),
+                            std::istreambuf_iterator<char>());
+  inFile.close();
 
-    auto start = std::chrono::high_resolution_clock::now();
-    spz::GaussianCloud cloud = spz::loadSpz(data);
-    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
-                        std::chrono::high_resolution_clock::now() - start)
-                        .count();
-    std::cout << "Decompression completed in " << duration << " ms.\n";
+  auto start = std::chrono::high_resolution_clock::now();
+  spz::GaussianCloud cloud = spz::loadSpz(data);
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+                      std::chrono::high_resolution_clock::now() - start)
+                      .count();
+  std::cout << "Decompression completed in " << duration << " ms.\n";
 
-    if (cloud.numPoints == 0) {
-        std::cerr << "Failed to decompress SPZ file or empty Gaussian cloud.\n";
-        return 1;
-    }
+  if (cloud.numPoints == 0) {
+    std::cerr << "Failed to decompress SPZ file or empty Gaussian cloud.\n";
+    return 1;
+  }
 
-    if (spz::saveSplatToPly(cloud, options.outputFilename, options.includeNormals)) {
-        std::cout << "Successfully saved Gaussian cloud to " << options.outputFilename << "\n";
-    } else {
-        std::cerr << "Failed to save Gaussian cloud to " << options.outputFilename << "\n";
-        return 1;
-    }
+  if (spz::saveSplatToPly(cloud, options.outputFilename,
+                          options.includeNormals)) {
+    std::cout << "Successfully saved Gaussian cloud to "
+              << options.outputFilename << "\n";
+  } else {
+    std::cerr << "Failed to save Gaussian cloud to " << options.outputFilename
+              << "\n";
+    return 1;
+  }
 
-    return 0;
+  return 0;
 }
 
 int main(int argc, char *argv[]) {
-    ProgramOptions options;
+  ProgramOptions options;
 
-    if (!parseArguments(argc, argv, options)) {
-        return 1;
-    }
+  if (!parseArguments(argc, argv, options)) {
+    return 1;
+  }
 
-    try {
-        return options.compress ? compressFile(options) : decompressFile(options);
-    } catch (const std::exception &e) {
-        std::cerr << "Exception: " << e.what() << "\n";
-        return 1;
-    }
+  try {
+    return options.compress ? compressFile(options) : decompressFile(options);
+  } catch (const std::exception &e) {
+    std::cerr << "Exception: " << e.what() << "\n";
+    return 1;
+  }
 }

--- a/src/cc/python/bindings.cc
+++ b/src/cc/python/bindings.cc
@@ -13,7 +13,7 @@ PYBIND11_MODULE(pyspz, m) {
     m.doc() = "Python bindings for SPZ compression/decompression";
 
     m.def("compress",
-          [](const py::buffer &rawData, int compressionLevel = 1) {
+          [](const py::buffer &rawData, int compressionLevel = 1, int workers = 1) {
               py::buffer_info buf = rawData.request();
               if (buf.format != py::format_descriptor<uint8_t>::format()) {
                   throw std::runtime_error("Expected buffer of type uint8");
@@ -25,7 +25,7 @@ PYBIND11_MODULE(pyspz, m) {
               );
 
               std::vector<uint8_t> compressedData;
-              bool success = spz::compress(data, compressionLevel, compressedData);
+              bool success = spz::compress(data, compressionLevel, workers, compressedData);
               if (!success) {
                   throw std::runtime_error("Compression failed");
               }
@@ -37,7 +37,8 @@ PYBIND11_MODULE(pyspz, m) {
           },
           py::arg("raw_data"),
           py::arg("compression_level") = 1,
-          "Compress PLY raw data with the specified compression level."
+          py::arg("workers") = 1,
+          "Compress PLY raw data with the specified compression level and number of workers."
     );
 
 


### PR DESCRIPTION
This PR adds the following:

1. Fetches the ZSTD source code using CMake.
2. Enables ZSTD multi-threaded support.
3. Builds ZSTD in static mode.
4. Adds a "workers" parameter to C++ code and Python bindings.