### PR TITLE
Improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ In my tests for this project, Clang 19.1.7 generated significantly better code t
 The resulting file hash after decompression by SPZ will differ if the library is compiled with -O3 -march=x86-64-v3 versus using just -O2 or -O3, due to differences in instruction generation, floating-point operation handling, and compiler-specific optimizations.\
 Furthermore, even when compiling with identical flags (e.g., -march=x86-64-v3), the file hash will still differ between GCC and Clang builds for the same reasons.
 
+## Installation for Python Environment
+To compile the project, you need a **C++20 compiler** such as Clang or GCC, along with CMake version 3.29.
+```bash
+git clone https://github.com/404-Repo/spz
+cd spz
+pip install .
+```
+If you prefer compiled package, you can download and install the WHL package from the [release page](https://github.com/404-Repo/spz/releases).
+
+## WASM
+The project includes a WebAssembly module demo, which you can find in [src/html/index.html](src/html/index.html).<br>
+A full SPZ WASM example can be downloaded from the [release page](https://github.com/404-Repo/spz/releases).
+
 ## C++ Interface
 ```C
 std::vector<uint8_t> compress(const std::vector<uint8_t> &rawData, int compressionLevel);
@@ -43,89 +56,6 @@ def decompress(input_data: bytes, include_normals: bool) -> bytes:
     :raises RuntimeError: If decompression fails.
     """
 ```
-
-## File Format
-The .spz format utilizes a zstd-compressed stream of data, consisting of a 16-byte header followed by the Gaussian data. This data is organized by attribute in the following order: positions,
-alphas, colors, scales, rotations and spherical harmonics.
-
-### Header
-
-```c
-struct PackedGaussiansHeader {
-  uint32_t magic;
-  uint32_t version;
-  uint32_t numPoints;
-  uint8_t shDegree;
-  uint8_t fractionalBits;
-  uint8_t flags;
-  uint8_t reserved;
-};
-```
-
-All values are little-endian.
-
-1. **magic**: This is always 0x5053474e
-2. **version**: Currently, the only valid version is 2
-3. **numPoints**: The number of gaussians
-4. **shDegree**: The degree of spherical harmonics. This must be between 0 and 3 (inclusive).
-5. **fractionalBits**: The number of bits used to store the fractional part of coordinates in
-   the fixed-point encoding.
-6. **flags**: A bit field containing flags.
-   - `0x1`: whether the splat was trained with [antialiasing](https://niujinshuchong.github.io/mip-splatting/).
-7. **reserved**: Reserved for future use. Must be 0.
-
-
-### Positions
-
-Positions are represented as `(x, y, z)` coordinates, each as a 24-bit fixed point signed integer.
-The number of fractional bits is determined by the `fractionalBits` field in the header.
-
-### Scales
-
-Scales are represented as `(x, y, z)` components, each represented as an 8-bit log-encoded integer.
-
-### Rotation
-
-Rotations are represented as the `(x, y, z)` components of the normalized rotation quaternion. The
-`w` component can be derived from the others and is not stored. Each components is encoded as an
-8-bit signed integer.
-
-### Alphas
-
-Alphas are represented as 8-bit unsigned integers.
-
-### Colors
-
-Colors are stored as `(r, g, b)` values, where each color component is represented as an
-unsigned 8-bit integer.
-
-### Spherical Harmonics
-
-Depending on the degree of spherical harmonics for the splat, this can contain 0 (for degree 0),
-9 (for degree 1), 24 (for degree 2), or 45 (for degree 3) coefficients per gaussian.
-
-The coefficients for a gaussian are organized such that the color channel is the inner (faster
-varying) axis, and the coefficient is the outer (slower varying) axis, i.e. for degree 1,
-the order of the 9 values is:
-```
-sh1n1_r, sh1n1_g, sh1n1_b, sh10_r, sh10_g, sh10_b, sh1p1_r, sh1p1_g, sh1p1_b
-```
-
-Each coefficient is represented as an 8-bit signed integer. Additional quantization can be performed
-to attain a higher compression ratio. This library currently uses 5 bits of precision for degree 0
-and 4 bits of precision for degrees 1 and 2, but this may be changed in the future without breaking
-backwards compatibility.
-
-## Installation for Python Environment
-```bash
-git clone https://github.com/404-Repo/spz
-cd spz
-pip install .
-```
-
-## WASM example
-The project includes a WebAssembly module demo, which you can find in [src/html/index.html](src/html/index.html).
-It will be copied to the build directory where the js and wasm module will be located after the build.
 
 ## Python example
 

--- a/SPZ_FORMAT.md
+++ b/SPZ_FORMAT.md
@@ -1,0 +1,71 @@
+## File Format
+The .spz format utilizes a zstd-compressed stream of data, consisting of a 16-byte header followed by the Gaussian data. This data is organized by attribute in the following order: positions,
+alphas, colors, scales, rotations and spherical harmonics.
+
+### Header
+
+```c
+struct PackedGaussiansHeader {
+  uint32_t magic;
+  uint32_t version;
+  uint32_t numPoints;
+  uint8_t shDegree;
+  uint8_t fractionalBits;
+  uint8_t flags;
+  uint8_t reserved;
+};
+```
+
+All values are little-endian.
+
+1. **magic**: This is always 0x5053474e
+2. **version**: Currently, the only valid version is 2
+3. **numPoints**: The number of gaussians
+4. **shDegree**: The degree of spherical harmonics. This must be between 0 and 3 (inclusive).
+5. **fractionalBits**: The number of bits used to store the fractional part of coordinates in
+   the fixed-point encoding.
+6. **flags**: A bit field containing flags.
+   - `0x1`: whether the splat was trained with [antialiasing](https://niujinshuchong.github.io/mip-splatting/).
+7. **reserved**: Reserved for future use. Must be 0.
+
+
+### Positions
+
+Positions are represented as `(x, y, z)` coordinates, each as a 24-bit fixed point signed integer.
+The number of fractional bits is determined by the `fractionalBits` field in the header.
+
+### Scales
+
+Scales are represented as `(x, y, z)` components, each represented as an 8-bit log-encoded integer.
+
+### Rotation
+
+Rotations are represented as the `(x, y, z)` components of the normalized rotation quaternion. The
+`w` component can be derived from the others and is not stored. Each components is encoded as an
+8-bit signed integer.
+
+### Alphas
+
+Alphas are represented as 8-bit unsigned integers.
+
+### Colors
+
+Colors are stored as `(r, g, b)` values, where each color component is represented as an
+unsigned 8-bit integer.
+
+### Spherical Harmonics
+
+Depending on the degree of spherical harmonics for the splat, this can contain 0 (for degree 0),
+9 (for degree 1), 24 (for degree 2), or 45 (for degree 3) coefficients per gaussian.
+
+The coefficients for a gaussian are organized such that the color channel is the inner (faster
+varying) axis, and the coefficient is the outer (slower varying) axis, i.e. for degree 1,
+the order of the 9 values is:
+```
+sh1n1_r, sh1n1_g, sh1n1_b, sh10_r, sh10_g, sh10_b, sh1p1_r, sh1p1_g, sh1p1_b
+```
+
+Each coefficient is represented as an 8-bit signed integer. Additional quantization can be performed
+to attain a higher compression ratio. This library currently uses 5 bits of precision for degree 0
+and 4 bits of precision for degrees 1 and 2, but this may be changed in the future without breaking
+backwards compatibility.


### PR DESCRIPTION
1. Clarify the installation process for Python.
2. Move the file specification to a separate document.