### PR TITLE
Add HEAPU8 to EXPORTED_RUNTIME_METHODS

### DIFF
--- a/.github/workflows/spz.yml
+++ b/.github/workflows/spz.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Setup Emscripten SDK
         uses: mymindstorm/setup-emsdk@v14
         with:
-          version: 4.0.9
+          version: 4.0.10
 
       - name: Configure and build SPZ WASM
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,7 @@ if(IS_WASM)
         "-sWASM=1"
         "-sMODULARIZE=0"
         "-sEXPORTED_FUNCTIONS=['_compress_spz','_decompress_spz','_malloc','_free']"
-        "-sEXPORTED_RUNTIME_METHODS=['ccall','cwrap','getValue']"
+        "-sEXPORTED_RUNTIME_METHODS=['ccall','cwrap','getValue','HEAPU8']"
         "-sALLOW_MEMORY_GROWTH=1"
         "-sINITIAL_MEMORY=268435456"  # 256 MB initial memory
     )

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ If you prefer compiled package, you can download and install the WHL package fro
 The project includes a WebAssembly module demo, which you can find in [src/html/index.html](src/html/index.html).<br>
 A full SPZ WASM example can be downloaded from the [release page](https://github.com/404-Repo/spz/releases).
 
+## C++ Build shared libraries and console utilities
+You can use [Ninja generator](https://ninja-build.org/) to speed up the build.
+```bash
+mkdir build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release .. && cmake --build . -- -j$(nproc)
+```
+
 ## C++ Interface
 ```C
 std::vector<uint8_t> compress(const std::vector<uint8_t> &rawData, int compressionLevel);


### PR DESCRIPTION
When integrating with Next.js locally, I encountered errors indicating that Module.HEAPU8 is undefined, even though I accessed the Module.HEAPU8 property in JavaScript generated by older compiler versions without issues. To be safe, I added it to EXPORTED_RUNTIME_METHODS. I also included documentation on building the shared library and console utility.

This led to the change in updateMemoryViews in spz_wasm.js:
```diff
function updateMemoryViews() {
    var b = wasmMemory.buffer;
    HEAP8 = new Int8Array(b);
    HEAP16 = new Int16Array(b);
-   HEAPU8 = new Uint8Array(b);
+   Module["HEAPU8"] = HEAPU8 = new Uint8Array(b);
    HEAPU16 = new Uint16Array(b);
    HEAP32 = new Int32Array(b);
    HEAPU32 = new Uint32Array(b);
    HEAPF32 = new Float32Array(b);
    HEAPF64 = new Float64Array(b);
    HEAP64 = new BigInt64Array(b);
    HEAPU64 = new BigUint64Array(b)
}
```